### PR TITLE
Ownership

### DIFF
--- a/ownership/src/main.rs
+++ b/ownership/src/main.rs
@@ -1,0 +1,29 @@
+fn main() {
+    let _s1 = gives_ownership();         // gives_ownership moves its return
+                                        // value into s1
+
+    let s2 = String::from("hello");     // s2 comes into scope
+
+    let _s3 = takes_and_gives_back(s2);  // s2 is moved into
+                                        // takes_and_gives_back, which also
+                                        // moves its return value into s3
+} // Here, s3 goes out of scope and is dropped. s2 was moved, so nothing
+  // happens. s1 goes out of scope and is dropped.
+
+fn gives_ownership() -> String {             // gives_ownership will move its
+                                             // return value into the function
+                                             // that calls it
+
+    let some_string = String::from("yours"); // some_string comes into scope
+
+    some_string                              // some_string is returned and
+                                             // moves out to the calling
+                                             // function
+}
+
+// This function takes a String and returns one
+fn takes_and_gives_back(a_string: String) -> String { // a_string comes into
+                                                      // scope
+
+    a_string  // a_string is returned and moves out to the calling function
+}


### PR DESCRIPTION
In Rust, when values within a function (like `main()`) are used as parameters to other functions, their ownership is moved to that function and they go out of scope. However, this only applies to values that don't implement the `Copy` trait. Values with a known size at compile time, such as integers, implement `Copy` and can be copied instead of moved (this is done implicitly). Therefore, ownership is only moved for variables stored on the heap, while stack-allocated values like integers are copied.